### PR TITLE
cleanup query compiler and extension behavior

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,8 @@ import { CompiledQuery, Kysely } from "kysely";
 
 type CompiledQuerySchema<T> = T extends SelectQueryBuilder<any, any, infer O> ? Simplify<O> : never;
 
+const ID_WRAP_REGEX = /"/g;
+
 /**
  * @alpha
  * Kysely extension methods.
@@ -35,7 +37,7 @@ export class KyselyDuckDbExtension<DB> extends Kysely<DB> {
     for (const tableName of tableNames) {
       const table = tables[tableName].compile();
       const query = CompiledQuery.raw(
-        `CREATE TABLE ${String(tableName)} AS (${table.sql})`,
+        `CREATE TABLE ${quoteTableName(String(tableName))} AS (${table.sql})`,
         [...table.parameters],
       );
       await this.executeQuery(query);
@@ -43,4 +45,16 @@ export class KyselyDuckDbExtension<DB> extends Kysely<DB> {
 
     return this as Kysely<DB & { [K in keyof T]: CompiledQuerySchema<T[K]>; }>;
   }
+}
+
+function quoteTableName(tableName: string): string {
+  return tableName.split(".").map(quoteIdentifier).join(".");
+}
+
+function quoteIdentifier(identifier: string): string {
+  if (identifier === "") {
+    throw new Error("DuckDB CTAS table names cannot contain empty identifier parts.");
+  }
+
+  return `"${identifier.replace(ID_WRAP_REGEX, "\"\"")}"`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,3 +77,5 @@ export class DuckDbDialect implements Dialect {
 
 export * as datatypes from "./helper/datatypes";
 export type { DuckDBNodeDataTypes } from "./helper/datatypes";
+export type { DuckDbNodeDriverConfig } from "./driver-node";
+export type { DuckDbQueryCompilerConfigs } from "./query-compiler";

--- a/src/introspector.ts
+++ b/src/introspector.ts
@@ -54,7 +54,6 @@ export class DuckDbIntrospector implements DatabaseIntrospector {
         .where("columns.TABLE_NAME", "!=", DEFAULT_MIGRATION_LOCK_TABLE);
     }
 
-    console.log(query.compile());
     const rawColumns = await query.execute();
     return this.#parseTableMetadata(rawColumns);
   }
@@ -68,7 +67,6 @@ export class DuckDbIntrospector implements DatabaseIntrospector {
   }
 
   #parseTableMetadata(columns: RawColumnMetadata[]): TableMetadata[] {
-    console.log(columns);
     return columns.reduce<TableMetadata[]>((tables, it) => {
       let table = tables.find((tbl) => tbl.name === it.table_name);
 

--- a/src/query-compiler.ts
+++ b/src/query-compiler.ts
@@ -43,7 +43,7 @@ export interface DuckDbQueryCompilerConfigs {
    * await db.withSchema("neon").selectFrom("person").selectAll().execute();
    * ```
    */
-  tableMappings: {
+  tableMappings?: {
     [tableName: string]: string;
   };
 }
@@ -53,7 +53,7 @@ export class DuckDbQueryCompiler extends DefaultQueryCompiler {
 
   constructor(configs: DuckDbQueryCompilerConfigs) {
     super();
-    this.#configs = configs;
+    this.#configs = { tableMappings: {}, ...configs };
   }
 
   protected override getCurrentParameterPlaceholder() {
@@ -85,7 +85,7 @@ export class DuckDbQueryCompiler extends DefaultQueryCompiler {
   }
 
   protected visitTable(node: TableNode): void {
-    const mappings = this.#configs.tableMappings;
+    const mappings = this.#configs.tableMappings ?? {};
     const table = node.table.identifier.name;
     const schema = node.table.schema?.name;
 

--- a/tests/code_quality.test.ts
+++ b/tests/code_quality.test.ts
@@ -1,0 +1,68 @@
+import { DuckDBInstance } from "@duckdb/node-api";
+import { CompiledQuery, Kysely } from "kysely";
+import { KyselyDuckDbExtension } from "../src/extension";
+import { DuckDbDialect } from "../src/index";
+import { setupDb } from "./test_common";
+
+test("introspection does not emit console output", async () => {
+  const kysely = await setupDb();
+  const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+  try {
+    await kysely.introspection.getTables();
+    expect(logSpy).not.toHaveBeenCalled();
+  } finally {
+    logSpy.mockRestore();
+  }
+});
+
+test("tableMappings can be omitted for regular table usage", async () => {
+  const db = await DuckDBInstance.create(":memory:");
+  const kysely = new Kysely<{ t1: { a: number; }; }>({
+    dialect: new DuckDbDialect({ database: db }),
+  });
+
+  await kysely.executeQuery(CompiledQuery.raw("CREATE TABLE t1 (a INT);"));
+  await kysely.executeQuery(CompiledQuery.raw("INSERT INTO t1 VALUES (1);"));
+
+  const rows = await kysely.selectFrom("t1").selectAll().execute();
+  expect(rows).toEqual([{ a: 1 }]);
+});
+
+test("createTablesAsSelect quotes generated table names", async () => {
+  const db = await DuckDBInstance.create(":memory:");
+  const kysely = new KyselyDuckDbExtension<{ source: { a: number; }; }>({
+    dialect: new DuckDbDialect({ database: db }),
+  });
+  const unsafeTableName = `quoted " table; DROP TABLE source; --`;
+
+  await kysely.executeQuery(CompiledQuery.raw("CREATE TABLE source (a INT);"));
+  await kysely.executeQuery(CompiledQuery.raw("INSERT INTO source VALUES (1);"));
+
+  const dbWithTable = await kysely.createTablesAsSelect({
+    [unsafeTableName]: kysely.selectFrom("source").select("a"),
+  });
+
+  const rows = await dbWithTable.selectFrom(unsafeTableName).selectAll().execute();
+  const sourceRows = await kysely.selectFrom("source").selectAll().execute();
+  expect(rows).toEqual([{ a: 1 }]);
+  expect(sourceRows).toEqual([{ a: 1 }]);
+});
+
+test("createTablesAsSelect supports schema-qualified generated table names", async () => {
+  const db = await DuckDBInstance.create(":memory:");
+  const kysely = new KyselyDuckDbExtension<{ source: { a: number; }; "scratch.generated": { a: number; }; }>({
+    dialect: new DuckDbDialect({ database: db }),
+  });
+
+  await kysely.executeQuery(CompiledQuery.raw("CREATE SCHEMA scratch;"));
+  await kysely.executeQuery(CompiledQuery.raw("CREATE TABLE source (a INT);"));
+  await kysely.executeQuery(CompiledQuery.raw("INSERT INTO source VALUES (1);"));
+
+  const dbWithTable = await kysely.createTablesAsSelect({
+    "scratch.generated": kysely.selectFrom("source").select("a"),
+  });
+
+  const rows = await dbWithTable.selectFrom("scratch.generated").selectAll().execute();
+  expect(rows).toEqual([{ a: 1 }]);
+});


### PR DESCRIPTION
## Summary

- Preserve the schema-aware table mapping behavior from PR #10 while making query compiler config optional.
- Tighten `createTablesAsSelect` handling for quoted and schema-qualified table names.
- Remove stray introspector console output and export driver/query compiler config types.
- Add focused coverage for omitted table mappings, CTAS quoting/schema behavior, and console cleanliness.

## Validation

- `TZ=UTC pnpm run check`
- `TZ=UTC pnpm exec jest --testPathIgnorePatterns=.ralph`
- `pnpm run build`

## Notes

This PR is intended to be reviewed and merged before `feat/duckdb-wasm-compat`, which is stacked on top of this branch.