### PR TITLE
feat: add DuckDB WASM compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Please see following instructions and [API Reference](https://runoshun.github.io
 $ npm install --save kysely @duckdb/node-api kysely-duckdb
 ```
 
+For the WASM dialect, install the WASM runtime dependencies instead of
+`@duckdb/node-api`:
+
+```bash
+$ npm install --save kysely kysely-duckdb @duckdb/duckdb-wasm@1.32.0 web-worker
+```
+
+`@duckdb/duckdb-wasm@1.32.0` is the stable runtime version tested by this
+package for the Node-compatible WASM smoke path.
+
 ### Usage
 
 ```ts
@@ -35,6 +45,52 @@ const archived = await kysely.withSchema("archive").selectFrom("person")
   .selectAll().execute();
 ```
 
+### WASM Usage
+
+The WASM dialect is exported from a separate subpath so the default node-api
+entry point does not import `@duckdb/duckdb-wasm` runtime code.
+
+```ts
+import { Kysely } from "kysely";
+import { createDuckDbWasmDatabase, DuckDbWasmDialect } from "kysely-duckdb/wasm-node";
+
+interface Database {
+  person: {
+    id: number;
+    first_name: string;
+  };
+}
+
+const duckdb = await createDuckDbWasmDatabase();
+const kysely = new Kysely<Database>({
+  dialect: new DuckDbWasmDialect({
+    database: duckdb,
+    tableMappings: {},
+  }),
+});
+
+await kysely.schema
+  .createTable("person")
+  .addColumn("id", "integer")
+  .addColumn("first_name", "varchar")
+  .execute();
+
+await kysely.insertInto("person").values({ id: 1, first_name: "Ada" }).execute();
+const rows = await kysely.selectFrom("person").selectAll().execute();
+
+await kysely.destroy();
+```
+
+`createDuckDbWasmDatabase` creates an in-memory `AsyncDuckDB` using
+`@duckdb/duckdb-wasm`'s Node worker files and `web-worker`. If you already have
+an instantiated `AsyncDuckDB`, import `DuckDbWasmDialect` from
+`kysely-duckdb/wasm` and pass it as `database`.
+
+Browser bundlers must provide DuckDB WASM and worker URLs using
+`@duckdb/duckdb-wasm`'s bundler-specific setup. The Node-compatible WASM smoke
+path is tested in this package; full browser E2E, OPFS persistence, and external
+file registration are not covered yet.
+
 ### Configrations
 
 The configuration object of `DuckDbDialect` can contain the following
@@ -53,6 +109,12 @@ When a schema is specified via `.withSchema()` but no matching schema-qualified
 key exists in `tableMappings`, the query bypasses table mappings entirely. This
 allows you to query attached databases directly while still using mappings for
 local data sources.
+
+The configuration object of `DuckDbWasmDialect` has the same `tableMappings`
+option, plus:
+
+- `database`: An already instantiated `AsyncDuckDB` instance or a function that returns one.
+- `onCreateConnection`: An optional callback that receives each `AsyncDuckDBConnection`.
 
 ### DuckDB DataTypes Supports (Experimental Feature)
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "./wasm-node": {
       "types": "./dist/wasm-node.d.ts",
       "require": "./dist/wasm-node.js",
-      "import": "./dist/wasm-node.js"
+      "import": "./dist/wasm-node.mjs"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,13 +3,25 @@
   "version": "0.3.0",
   "description": "kysely dialect for duckdb",
   "exports": {
-    "require": "./dist/index.js",
-    "import": "./dist/index.mjs",
-    "types": "./dist/index.d.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./wasm": {
+      "types": "./dist/wasm.d.ts",
+      "require": "./dist/wasm.js",
+      "import": "./dist/wasm.mjs"
+    },
+    "./wasm-node": {
+      "types": "./dist/wasm-node.d.ts",
+      "require": "./dist/wasm-node.js",
+      "import": "./dist/wasm-node.js"
+    }
   },
   "scripts": {
     "test": "jest",
-    "build": "rimraf ./dist && tsup src/index.ts --format cjs,esm --dts --sourcemap",
+    "build": "rimraf ./dist && tsup src/index.ts src/wasm.ts src/wasm-node.ts --format cjs,esm --dts --sourcemap",
     "check": "tsc --noEmit",
     "docs": "typedoc src/index.ts",
     "all": "npm run check && npm run test && npm run build && npm run docs"
@@ -22,7 +34,8 @@
   "author": "runoshun",
   "license": "MIT",
   "devDependencies": {
-    "@duckdb/node-api": "^1.3.4-alpha.27",
+    "@duckdb/duckdb-wasm": "1.32.0",
+    "@duckdb/node-api": "1.5.2-r.1",
     "@tsconfig/node18": "^18.2.2",
     "@types/jest": "^29.5.5",
     "@types/node": "^20.7.0",
@@ -32,10 +45,24 @@
     "ts-jest": "^29.1.1",
     "tsup": "^7.2.0",
     "typedoc": "^0.25.1",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "web-worker": "1.2.0"
   },
   "peerDependencies": {
+    "@duckdb/duckdb-wasm": "*",
     "@duckdb/node-api": "*",
-    "kysely": "*"
+    "kysely": "*",
+    "web-worker": "*"
+  },
+  "peerDependenciesMeta": {
+    "@duckdb/duckdb-wasm": {
+      "optional": true
+    },
+    "@duckdb/node-api": {
+      "optional": true
+    },
+    "web-worker": {
+      "optional": true
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,9 +12,12 @@ importers:
         specifier: '*'
         version: 0.28.7
     devDependencies:
+      '@duckdb/duckdb-wasm':
+        specifier: 1.32.0
+        version: 1.32.0
       '@duckdb/node-api':
-        specifier: ^1.3.4-alpha.27
-        version: 1.3.4-alpha.27
+        specifier: 1.5.2-r.1
+        version: 1.5.2-r.1
       '@tsconfig/node18':
         specifier: ^18.2.2
         version: 18.2.4
@@ -45,6 +48,9 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.9.2
+      web-worker:
+        specifier: 1.2.0
+        version: 1.2.0
 
 packages:
 
@@ -214,200 +220,211 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@dprint/darwin-arm64@0.41.0':
-    resolution: {integrity: sha512-P9PtcQI0mrI4U6yyd+/iI664BHSqC9KTS6ogq0ptEdnLtlaWzf09D1nv6FBaHiG9m3conuBRlPsoUqt3j6PZ2w==}
+    resolution: {integrity: sha512-P9PtcQI0mrI4U6yyd+/iI664BHSqC9KTS6ogq0ptEdnLtlaWzf09D1nv6FBaHiG9m3conuBRlPsoUqt3j6PZ2w==, tarball: https://registry.npmjs.org/@dprint/darwin-arm64/-/darwin-arm64-0.41.0.tgz}
     cpu: [arm64]
     os: [darwin]
 
   '@dprint/darwin-x64@0.41.0':
-    resolution: {integrity: sha512-mSYnSoH0uyCkjgIWTny2DZAcaiRTe3kRWY5SeZECLGO37e+SdVg+ZjSzndhOvvEb9pv8EeBO1NJ9gHOSceT5Xw==}
+    resolution: {integrity: sha512-mSYnSoH0uyCkjgIWTny2DZAcaiRTe3kRWY5SeZECLGO37e+SdVg+ZjSzndhOvvEb9pv8EeBO1NJ9gHOSceT5Xw==, tarball: https://registry.npmjs.org/@dprint/darwin-x64/-/darwin-x64-0.41.0.tgz}
     cpu: [x64]
     os: [darwin]
 
   '@dprint/linux-arm64-glibc@0.41.0':
-    resolution: {integrity: sha512-U4xWzjjO/aAct8cSSMZFhg8l1jWy6VahXh8zWjGBufwX7t3xEcxMG9RyAp/ioYSY6wl4YXAmnUHywhC+wSjDHQ==}
+    resolution: {integrity: sha512-U4xWzjjO/aAct8cSSMZFhg8l1jWy6VahXh8zWjGBufwX7t3xEcxMG9RyAp/ioYSY6wl4YXAmnUHywhC+wSjDHQ==, tarball: https://registry.npmjs.org/@dprint/linux-arm64-glibc/-/linux-arm64-glibc-0.41.0.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-x64-glibc@0.41.0':
-    resolution: {integrity: sha512-wjv5l4mGns7E8i32E8FfAk45tw5O7v4NM17gtvhe6ggOiOD6quHowOH00pLfEakMLMF9y0J5ZO2hxJ/w06bXmQ==}
+    resolution: {integrity: sha512-wjv5l4mGns7E8i32E8FfAk45tw5O7v4NM17gtvhe6ggOiOD6quHowOH00pLfEakMLMF9y0J5ZO2hxJ/w06bXmQ==, tarball: https://registry.npmjs.org/@dprint/linux-x64-glibc/-/linux-x64-glibc-0.41.0.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@dprint/linux-x64-musl@0.41.0':
-    resolution: {integrity: sha512-ZZOqiur9Xi/2uhz0Ce215VTSajAlSrduX/5k/hpIjI7Rgz22Vn77p5fmYxzWkTt/Li1zq5zboTvmGYx0QVNMrQ==}
+    resolution: {integrity: sha512-ZZOqiur9Xi/2uhz0Ce215VTSajAlSrduX/5k/hpIjI7Rgz22Vn77p5fmYxzWkTt/Li1zq5zboTvmGYx0QVNMrQ==, tarball: https://registry.npmjs.org/@dprint/linux-x64-musl/-/linux-x64-musl-0.41.0.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@dprint/win32-x64@0.41.0':
-    resolution: {integrity: sha512-mFx6x4Hn848/D4gPbDm7g1wlnOh2SGoVF9c9HMGCuOobUU2WIBztzV4L5qlFCB3gprlS0ru9BhlMpGhrp0CBYA==}
+    resolution: {integrity: sha512-mFx6x4Hn848/D4gPbDm7g1wlnOh2SGoVF9c9HMGCuOobUU2WIBztzV4L5qlFCB3gprlS0ru9BhlMpGhrp0CBYA==, tarball: https://registry.npmjs.org/@dprint/win32-x64/-/win32-x64-0.41.0.tgz}
     cpu: [x64]
     os: [win32]
 
-  '@duckdb/node-api@1.3.4-alpha.27':
-    resolution: {integrity: sha512-XRQYqogzW4FrGzRjXn47d1BB8kY7DPkcU/gtircMtxoK5vYNq4YYCvyLrh/scQWTK3OxgWBNyDQA1TowSMiHqg==}
+  '@duckdb/duckdb-wasm@1.32.0':
+    resolution: {integrity: sha512-IewXTNYEjsZCPE9weUWgtjGxUlMRo7qhX0GF6tq/KjK8bnY+RAl4cyUdYUfcdzbyb4b9ZxPC+FOsCcxgaKFWMg==, tarball: https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.32.0.tgz}
 
-  '@duckdb/node-bindings-darwin-arm64@1.3.4-alpha.27':
-    resolution: {integrity: sha512-4umj8+qQJ79OegLItnNiacbTQUNW4nnCfldnAStYJb21ZjvlIfq6GPWRnWaZk2LFAn1+4ir8ySDkHZAI4jcUDQ==}
+  '@duckdb/node-api@1.5.2-r.1':
+    resolution: {integrity: sha512-OzBBnS0JGXMoS5mzKNY/Ylr7SshcRQiLFIoxQ4AlePwJ2fNeDL/fbHu/knjxUrXwW1fJBTUgwWftmxDdnZZb3A==}
+
+  '@duckdb/node-bindings-darwin-arm64@1.5.2-r.1':
+    resolution: {integrity: sha512-v35FyKOb8EJCvaiPF7k0gvKiJTXR7PPQDNoWR0Gu+YSX5O9b+DIguzt1348Of3HebHy6ATSMzlUekaVA9YXu+g==, tarball: https://registry.npmjs.org/@duckdb/node-bindings-darwin-arm64/-/node-bindings-darwin-arm64-1.5.2-r.1.tgz}
     cpu: [arm64]
     os: [darwin]
 
-  '@duckdb/node-bindings-darwin-x64@1.3.4-alpha.27':
-    resolution: {integrity: sha512-ZQAvxVxl4D5OHFlICuHs4RT961ZuVLvluvm+Nhgv5sbzh8PU9wO/x4NtfSpx0f82LoItgqUy2wxlpQx4Wdguvg==}
+  '@duckdb/node-bindings-darwin-x64@1.5.2-r.1':
+    resolution: {integrity: sha512-SU9dIJ1BluKkkGxi4UsP4keqkkstB2YDySF9KcYu3EZKIVM3FTv2zc7XO38dXnHOq6+F3WqhWWZvD+XU945p7A==, tarball: https://registry.npmjs.org/@duckdb/node-bindings-darwin-x64/-/node-bindings-darwin-x64-1.5.2-r.1.tgz}
     cpu: [x64]
     os: [darwin]
 
-  '@duckdb/node-bindings-linux-arm64@1.3.4-alpha.27':
-    resolution: {integrity: sha512-FGaZVRPhNvCNvlYGNF6MXnsklgBN+EKHaakaASQgS+IAVdojvB0mgpPJ5KapuSxKajZnLzRyng8EBomGq6TYDA==}
+  '@duckdb/node-bindings-linux-arm64@1.5.2-r.1':
+    resolution: {integrity: sha512-3Tra9xM3aM3denaER4KhJ6//6PpmPbik9ECBQ+sh9PyKaEgHw/0kAcKnLm5EzWUnXF0qYmZlewvkCrse8KmOYw==, tarball: https://registry.npmjs.org/@duckdb/node-bindings-linux-arm64/-/node-bindings-linux-arm64-1.5.2-r.1.tgz}
     cpu: [arm64]
     os: [linux]
 
-  '@duckdb/node-bindings-linux-x64@1.3.4-alpha.27':
-    resolution: {integrity: sha512-IPOxpEMdVqv7UKl3ffi9MHccX4xAzkFECo+ZWRjTlYAdxfg931bX187XP1H6/nh7aSzrbZq54RzuLXkZ6c1IlA==}
+  '@duckdb/node-bindings-linux-x64@1.5.2-r.1':
+    resolution: {integrity: sha512-pcQvZRHiIfJ9cq8parkSQczQHEml/IeGfnDCMAbEgD6+jaV9Y9Y5Ph1kP9aR+bm6him1S5ZIEr3kZbihjKnWbA==, tarball: https://registry.npmjs.org/@duckdb/node-bindings-linux-x64/-/node-bindings-linux-x64-1.5.2-r.1.tgz}
     cpu: [x64]
     os: [linux]
 
-  '@duckdb/node-bindings-win32-x64@1.3.4-alpha.27':
-    resolution: {integrity: sha512-j8WXM4IVZnOV6m2pbcaXnYmGjGWCpJSyuicwznB2bSSK1DpWia7MlgFa1+lOMfzB0Uzc5vo7ykURuZPbQukK8g==}
+  '@duckdb/node-bindings-win32-arm64@1.5.2-r.1':
+    resolution: {integrity: sha512-Ji8tym+N3LkrhVt0Up3bsacD/kpg4/JXFJQqxswiYvBaNCQOk+D+aiVS0GN5pcqvmnG7V7TpsDRzkLEFaWp1vw==, tarball: https://registry.npmjs.org/@duckdb/node-bindings-win32-arm64/-/node-bindings-win32-arm64-1.5.2-r.1.tgz}
+    cpu: [arm64]
+    os: [win32]
+
+  '@duckdb/node-bindings-win32-x64@1.5.2-r.1':
+    resolution: {integrity: sha512-5XqcqC+4R8ghBEEbnc2a0sqfz1zyPBRb9YcmIWfiuDoCYSYFbKhmHcEyNftZDHcwCoLOHXnUin45jraex4STqQ==, tarball: https://registry.npmjs.org/@duckdb/node-bindings-win32-x64/-/node-bindings-win32-x64-1.5.2-r.1.tgz}
     cpu: [x64]
     os: [win32]
 
-  '@duckdb/node-bindings@1.3.4-alpha.27':
-    resolution: {integrity: sha512-PjwplOefq0nGSnGRVetEdV++OmAiIhQSamNuE5p/XTKJoI1NGiwHbY2vuRk+c83U5QSZD7IWU28gANn8SR7Ong==}
+  '@duckdb/node-bindings@1.5.2-r.1':
+    resolution: {integrity: sha512-bUg3bLVj70YVku6fKyQJS8ASORl7kM7YFVFznsEB9pWbtazPj+ME2x2FUk0WiTzjJdutjzSSGXF066mB4bGGZA==}
 
   '@esbuild/aix-ppc64@0.19.12':
-    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
+    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==, tarball: https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [aix]
 
   '@esbuild/android-arm64@0.19.12':
-    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
+    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==, tarball: https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
 
   '@esbuild/android-arm@0.19.12':
-    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
+    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==, tarball: https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
 
   '@esbuild/android-x64@0.19.12':
-    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
+    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==, tarball: https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
 
   '@esbuild/darwin-arm64@0.19.12':
-    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
+    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==, tarball: https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.19.12':
-    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
+    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==, tarball: https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
 
   '@esbuild/freebsd-arm64@0.19.12':
-    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
+    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==, tarball: https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.19.12':
-    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
+    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==, tarball: https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
 
   '@esbuild/linux-arm64@0.19.12':
-    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
+    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==, tarball: https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
 
   '@esbuild/linux-arm@0.19.12':
-    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
+    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==, tarball: https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-ia32@0.19.12':
-    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
+    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==, tarball: https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
 
   '@esbuild/linux-loong64@0.19.12':
-    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
+    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==, tarball: https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-mips64el@0.19.12':
-    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
+    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==, tarball: https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.19.12':
-    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
+    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==, tarball: https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-riscv64@0.19.12':
-    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
+    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==, tarball: https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
 
   '@esbuild/linux-s390x@0.19.12':
-    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
+    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==, tarball: https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-x64@0.19.12':
-    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
+    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==, tarball: https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
 
   '@esbuild/netbsd-x64@0.19.12':
-    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
+    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==, tarball: https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
 
   '@esbuild/openbsd-x64@0.19.12':
-    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
+    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==, tarball: https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
 
   '@esbuild/sunos-x64@0.19.12':
-    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
+    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==, tarball: https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
 
   '@esbuild/win32-arm64@0.19.12':
-    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
+    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==, tarball: https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
 
   '@esbuild/win32-ia32@0.19.12':
-    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
+    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==, tarball: https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-x64@0.19.12':
-    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
+    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==, tarball: https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -519,111 +536,122 @@ packages:
     engines: {node: '>= 8'}
 
   '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==, tarball: https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz}
     engines: {node: '>=14'}
 
   '@rollup/rollup-android-arm-eabi@4.50.2':
-    resolution: {integrity: sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==}
+    resolution: {integrity: sha512-uLN8NAiFVIRKX9ZQha8wy6UUs06UNSZ32xj6giK/rmMXAgKahwExvK6SsmgU5/brh4w/nSgj8e0k3c1HBQpa0A==, tarball: https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.2.tgz}
     cpu: [arm]
     os: [android]
 
   '@rollup/rollup-android-arm64@4.50.2':
-    resolution: {integrity: sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g==}
+    resolution: {integrity: sha512-oEouqQk2/zxxj22PNcGSskya+3kV0ZKH+nQxuCCOGJ4oTXBdNTbv+f/E3c74cNLeMO1S5wVWacSws10TTSB77g==, tarball: https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.2.tgz}
     cpu: [arm64]
     os: [android]
 
   '@rollup/rollup-darwin-arm64@4.50.2':
-    resolution: {integrity: sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q==}
+    resolution: {integrity: sha512-OZuTVTpj3CDSIxmPgGH8en/XtirV5nfljHZ3wrNwvgkT5DQLhIKAeuFSiwtbMto6oVexV0k1F1zqURPKf5rI1Q==, tarball: https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.2.tgz}
     cpu: [arm64]
     os: [darwin]
 
   '@rollup/rollup-darwin-x64@4.50.2':
-    resolution: {integrity: sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A==}
+    resolution: {integrity: sha512-Wa/Wn8RFkIkr1vy1k1PB//VYhLnlnn5eaJkfTQKivirOvzu5uVd2It01ukeQstMursuz7S1bU+8WW+1UPXpa8A==, tarball: https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.2.tgz}
     cpu: [x64]
     os: [darwin]
 
   '@rollup/rollup-freebsd-arm64@4.50.2':
-    resolution: {integrity: sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow==}
+    resolution: {integrity: sha512-QkzxvH3kYN9J1w7D1A+yIMdI1pPekD+pWx7G5rXgnIlQ1TVYVC6hLl7SOV9pi5q9uIDF9AuIGkuzcbF7+fAhow==, tarball: https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.2.tgz}
     cpu: [arm64]
     os: [freebsd]
 
   '@rollup/rollup-freebsd-x64@4.50.2':
-    resolution: {integrity: sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog==}
+    resolution: {integrity: sha512-dkYXB0c2XAS3a3jmyDkX4Jk0m7gWLFzq1C3qUnJJ38AyxIF5G/dyS4N9B30nvFseCfgtCEdbYFhk0ChoCGxPog==, tarball: https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.2.tgz}
     cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.50.2':
-    resolution: {integrity: sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==}
+    resolution: {integrity: sha512-9VlPY/BN3AgbukfVHAB8zNFWB/lKEuvzRo1NKev0Po8sYFKx0i+AQlCYftgEjcL43F2h9Ui1ZSdVBc4En/sP2w==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.2.tgz}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.50.2':
-    resolution: {integrity: sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==}
+    resolution: {integrity: sha512-+GdKWOvsifaYNlIVf07QYan1J5F141+vGm5/Y8b9uCZnG/nxoGqgCmR24mv0koIWWuqvFYnbURRqw1lv7IBINw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.2.tgz}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.50.2':
-    resolution: {integrity: sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==}
+    resolution: {integrity: sha512-df0Eou14ojtUdLQdPFnymEQteENwSJAdLf5KCDrmZNsy1c3YaCNaJvYsEUHnrg+/DLBH612/R0xd3dD03uz2dg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.2.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.50.2':
-    resolution: {integrity: sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==}
+    resolution: {integrity: sha512-iPeouV0UIDtz8j1YFR4OJ/zf7evjauqv7jQ/EFs0ClIyL+by++hiaDAfFipjOgyz6y6xbDvJuiU4HwpVMpRFDQ==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.2.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.50.2':
-    resolution: {integrity: sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==}
+    resolution: {integrity: sha512-OL6KaNvBopLlj5fTa5D5bau4W82f+1TyTZRr2BdnfsrnQnmdxh4okMxR2DcDkJuh4KeoQZVuvHvzuD/lyLn2Kw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.50.2.tgz}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.50.2':
-    resolution: {integrity: sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==}
+    resolution: {integrity: sha512-I21VJl1w6z/K5OTRl6aS9DDsqezEZ/yKpbqlvfHbW0CEF5IL8ATBMuUx6/mp683rKTK8thjs/0BaNrZLXetLag==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.2.tgz}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.50.2':
-    resolution: {integrity: sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==}
+    resolution: {integrity: sha512-Hq6aQJT/qFFHrYMjS20nV+9SKrXL2lvFBENZoKfoTH2kKDOJqff5OSJr4x72ZaG/uUn+XmBnGhfr4lwMRrmqCQ==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.2.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.50.2':
-    resolution: {integrity: sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==}
+    resolution: {integrity: sha512-82rBSEXRv5qtKyr0xZ/YMF531oj2AIpLZkeNYxmKNN6I2sVE9PGegN99tYDLK2fYHJITL1P2Lgb4ZXnv0PjQvw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.2.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.50.2':
-    resolution: {integrity: sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==}
+    resolution: {integrity: sha512-4Q3S3Hy7pC6uaRo9gtXUTJ+EKo9AKs3BXKc2jYypEcMQ49gDPFU2P1ariX9SEtBzE5egIX6fSUmbmGazwBVF9w==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.2.tgz}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.50.2':
-    resolution: {integrity: sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==}
+    resolution: {integrity: sha512-9Jie/At6qk70dNIcopcL4p+1UirusEtznpNtcq/u/C5cC4HBX7qSGsYIcG6bdxj15EYWhHiu02YvmdPzylIZlA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.2.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.50.2':
-    resolution: {integrity: sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==}
+    resolution: {integrity: sha512-HPNJwxPL3EmhzeAnsWQCM3DcoqOz3/IC6de9rWfGR8ZCuEHETi9km66bH/wG3YH0V3nyzyFEGUZeL5PKyy4xvw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.2.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.50.2':
-    resolution: {integrity: sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==}
+    resolution: {integrity: sha512-nMKvq6FRHSzYfKLHZ+cChowlEkR2lj/V0jYj9JnGUVPL2/mIeFGmVM2mLaFeNa5Jev7W7TovXqXIG2d39y1KYA==, tarball: https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.2.tgz}
     cpu: [arm64]
     os: [openharmony]
 
   '@rollup/rollup-win32-arm64-msvc@4.50.2':
-    resolution: {integrity: sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA==}
+    resolution: {integrity: sha512-eFUvvnTYEKeTyHEijQKz81bLrUQOXKZqECeiWH6tb8eXXbZk+CXSG2aFrig2BQ/pjiVRj36zysjgILkqarS2YA==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.2.tgz}
     cpu: [arm64]
     os: [win32]
 
   '@rollup/rollup-win32-ia32-msvc@4.50.2':
-    resolution: {integrity: sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA==}
+    resolution: {integrity: sha512-cBaWmXqyfRhH8zmUxK3d3sAhEWLrtMjWBRwdMMHJIXSjvjLKvv49adxiEz+FJ8AP90apSDDBx2Tyd/WylV6ikA==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.2.tgz}
     cpu: [ia32]
     os: [win32]
 
   '@rollup/rollup-win32-x64-msvc@4.50.2':
-    resolution: {integrity: sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA==}
+    resolution: {integrity: sha512-APwKy6YUhvZaEoHyM+9xqmTpviEI+9eL7LoCH+aLcvWYHJ663qG5zx7WzWZY+a9qkg5JtzcMyJ9z0WtQBMDmgA==, tarball: https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.2.tgz}
     cpu: [x64]
     os: [win32]
 
@@ -635,6 +663,9 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@swc/helpers@0.5.21':
+    resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==, tarball: https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz}
 
   '@tsconfig/node18@18.2.4':
     resolution: {integrity: sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==}
@@ -650,6 +681,12 @@ packages:
 
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/command-line-args@5.2.3':
+    resolution: {integrity: sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==, tarball: https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz}
+
+  '@types/command-line-usage@5.0.4':
+    resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==, tarball: https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -715,8 +752,20 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  apache-arrow@17.0.0:
+    resolution: {integrity: sha512-X0p7auzdnGuhYMVKYINdQssS4EcKec9TCXyez/qtJt32DrIMGbzqiaMiQ0X6fQlQpw8Fl0Qygcv4dfRAr5Gu9Q==, tarball: https://registry.npmjs.org/apache-arrow/-/apache-arrow-17.0.0.tgz}
+    hasBin: true
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  array-back@3.1.0:
+    resolution: {integrity: sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==, tarball: https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz}
+    engines: {node: '>=6'}
+
+  array-back@6.2.3:
+    resolution: {integrity: sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==, tarball: https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz}
+    engines: {node: '>=12.17'}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -808,6 +857,10 @@ packages:
   caniuse-lite@1.0.30001741:
     resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
 
+  chalk-template@0.4.0:
+    resolution: {integrity: sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==, tarball: https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz}
+    engines: {node: '>=12'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -844,6 +897,14 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  command-line-args@5.2.1:
+    resolution: {integrity: sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==, tarball: https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz}
+    engines: {node: '>=4.0.0'}
+
+  command-line-usage@7.0.4:
+    resolution: {integrity: sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==, tarball: https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz}
+    engines: {node: '>=12.20.0'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -967,9 +1028,16 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-replace@3.0.0:
+    resolution: {integrity: sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==, tarball: https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz}
+    engines: {node: '>=4.0.0'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
+
+  flatbuffers@24.12.23:
+    resolution: {integrity: sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==, tarball: https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -979,12 +1047,12 @@ packages:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
-    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
   function-bind@1.1.2:
-    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==, tarball: https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1031,7 +1099,7 @@ packages:
     engines: {node: '>=8'}
 
   hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==, tarball: https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz}
     engines: {node: '>= 0.4'}
 
   html-escaper@2.0.2:
@@ -1271,6 +1339,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bignum@0.0.3:
+    resolution: {integrity: sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==, tarball: https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz}
+    engines: {node: '>=0.8'}
+
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
@@ -1308,6 +1380,9 @@ packages:
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
+
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==, tarball: https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz}
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -1642,6 +1717,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  table-layout@4.1.1:
+    resolution: {integrity: sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==, tarball: https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz}
+    engines: {node: '>=12.17'}
+
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
@@ -1697,6 +1776,9 @@ packages:
       jest-util:
         optional: true
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==, tarball: https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz}
+
   tsup@7.3.0:
     resolution: {integrity: sha512-Ja1eaSRrE+QarmATlNO5fse2aOACYMBX+IZRKy1T+gpyH+jXgRrl5l4nHIQJQ1DoDgEjHDTw8cpE085UdBZuWQ==}
     engines: {node: '>=18'}
@@ -1738,8 +1820,16 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typical@4.0.0:
+    resolution: {integrity: sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==, tarball: https://registry.npmjs.org/typical/-/typical-4.0.0.tgz}
+    engines: {node: '>=8'}
+
+  typical@7.3.0:
+    resolution: {integrity: sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==, tarball: https://registry.npmjs.org/typical/-/typical-7.3.0.tgz}
+    engines: {node: '>=12.17'}
+
   uglify-js@3.19.3:
-    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==, tarball: https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz}
     engines: {node: '>=0.8.0'}
     hasBin: true
 
@@ -1765,6 +1855,9 @@ packages:
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
+  web-worker@1.2.0:
+    resolution: {integrity: sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==, tarball: https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz}
+
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
@@ -1779,8 +1872,12 @@ packages:
   wordwrap@1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
+  wordwrapjs@5.1.1:
+    resolution: {integrity: sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==, tarball: https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz}
+    engines: {node: '>=12.17'}
+
   wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==, tarball: https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz}
     engines: {node: '>=10'}
 
   wrap-ansi@8.1.0:
@@ -2027,32 +2124,40 @@ snapshots:
   '@dprint/win32-x64@0.41.0':
     optional: true
 
-  '@duckdb/node-api@1.3.4-alpha.27':
+  '@duckdb/duckdb-wasm@1.32.0':
     dependencies:
-      '@duckdb/node-bindings': 1.3.4-alpha.27
+      apache-arrow: 17.0.0
 
-  '@duckdb/node-bindings-darwin-arm64@1.3.4-alpha.27':
+  '@duckdb/node-api@1.5.2-r.1':
+    dependencies:
+      '@duckdb/node-bindings': 1.5.2-r.1
+
+  '@duckdb/node-bindings-darwin-arm64@1.5.2-r.1':
     optional: true
 
-  '@duckdb/node-bindings-darwin-x64@1.3.4-alpha.27':
+  '@duckdb/node-bindings-darwin-x64@1.5.2-r.1':
     optional: true
 
-  '@duckdb/node-bindings-linux-arm64@1.3.4-alpha.27':
+  '@duckdb/node-bindings-linux-arm64@1.5.2-r.1':
     optional: true
 
-  '@duckdb/node-bindings-linux-x64@1.3.4-alpha.27':
+  '@duckdb/node-bindings-linux-x64@1.5.2-r.1':
     optional: true
 
-  '@duckdb/node-bindings-win32-x64@1.3.4-alpha.27':
+  '@duckdb/node-bindings-win32-arm64@1.5.2-r.1':
     optional: true
 
-  '@duckdb/node-bindings@1.3.4-alpha.27':
+  '@duckdb/node-bindings-win32-x64@1.5.2-r.1':
+    optional: true
+
+  '@duckdb/node-bindings@1.5.2-r.1':
     optionalDependencies:
-      '@duckdb/node-bindings-darwin-arm64': 1.3.4-alpha.27
-      '@duckdb/node-bindings-darwin-x64': 1.3.4-alpha.27
-      '@duckdb/node-bindings-linux-arm64': 1.3.4-alpha.27
-      '@duckdb/node-bindings-linux-x64': 1.3.4-alpha.27
-      '@duckdb/node-bindings-win32-x64': 1.3.4-alpha.27
+      '@duckdb/node-bindings-darwin-arm64': 1.5.2-r.1
+      '@duckdb/node-bindings-darwin-x64': 1.5.2-r.1
+      '@duckdb/node-bindings-linux-arm64': 1.5.2-r.1
+      '@duckdb/node-bindings-linux-x64': 1.5.2-r.1
+      '@duckdb/node-bindings-win32-arm64': 1.5.2-r.1
+      '@duckdb/node-bindings-win32-x64': 1.5.2-r.1
 
   '@esbuild/aix-ppc64@0.19.12':
     optional: true
@@ -2411,6 +2516,10 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@swc/helpers@0.5.21':
+    dependencies:
+      tslib: 2.8.1
+
   '@tsconfig/node18@18.2.4': {}
 
   '@types/babel__core@7.20.5':
@@ -2433,6 +2542,10 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.28.4
+
+  '@types/command-line-args@5.2.3': {}
+
+  '@types/command-line-usage@5.0.4': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2492,9 +2605,25 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
+  apache-arrow@17.0.0:
+    dependencies:
+      '@swc/helpers': 0.5.21
+      '@types/command-line-args': 5.2.3
+      '@types/command-line-usage': 5.0.4
+      '@types/node': 20.19.14
+      command-line-args: 5.2.1
+      command-line-usage: 7.0.4
+      flatbuffers: 24.12.23
+      json-bignum: 0.0.3
+      tslib: 2.8.1
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
+
+  array-back@3.1.0: {}
+
+  array-back@6.2.3: {}
 
   array-union@2.1.0: {}
 
@@ -2605,6 +2734,10 @@ snapshots:
 
   caniuse-lite@1.0.30001741: {}
 
+  chalk-template@0.4.0:
+    dependencies:
+      chalk: 4.1.2
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -2643,6 +2776,20 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  command-line-args@5.2.1:
+    dependencies:
+      array-back: 3.1.0
+      find-replace: 3.0.0
+      lodash.camelcase: 4.3.0
+      typical: 4.0.0
+
+  command-line-usage@7.0.4:
+    dependencies:
+      array-back: 6.2.3
+      chalk-template: 0.4.0
+      table-layout: 4.1.1
+      typical: 7.3.0
 
   commander@4.1.1: {}
 
@@ -2786,10 +2933,16 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-replace@3.0.0:
+    dependencies:
+      array-back: 3.1.0
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
+
+  flatbuffers@24.12.23: {}
 
   foreground-child@3.3.1:
     dependencies:
@@ -3271,6 +3424,8 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bignum@0.0.3: {}
+
   json-parse-even-better-errors@2.3.1: {}
 
   json5@2.2.3: {}
@@ -3292,6 +3447,8 @@ snapshots:
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
+
+  lodash.camelcase@4.3.0: {}
 
   lodash.memoize@4.1.2: {}
 
@@ -3594,6 +3751,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  table-layout@4.1.1:
+    dependencies:
+      array-back: 6.2.3
+      wordwrapjs: 5.1.1
+
   test-exclude@6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.3
@@ -3643,6 +3805,8 @@ snapshots:
       esbuild: 0.19.12
       jest-util: 29.7.0
 
+  tslib@2.8.1: {}
+
   tsup@7.3.0(typescript@5.9.2):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.19.12)
@@ -3681,6 +3845,10 @@ snapshots:
 
   typescript@5.9.2: {}
 
+  typical@4.0.0: {}
+
+  typical@7.3.0: {}
+
   uglify-js@3.19.3:
     optional: true
 
@@ -3706,6 +3874,8 @@ snapshots:
     dependencies:
       makeerror: 1.0.12
 
+  web-worker@1.2.0: {}
+
   webidl-conversions@4.0.2: {}
 
   whatwg-url@7.1.0:
@@ -3719,6 +3889,8 @@ snapshots:
       isexe: 2.0.0
 
   wordwrap@1.0.0: {}
+
+  wordwrapjs@5.1.1: {}
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/src/driver-wasm.ts
+++ b/src/driver-wasm.ts
@@ -1,17 +1,24 @@
-/*
-import duckdb from "@duckdb/duckdb-wasm";
-import arrow from "apache-arrow";
+import type { AsyncDuckDB, AsyncDuckDBConnection } from "@duckdb/duckdb-wasm";
 import { CompiledQuery } from "kysely";
 import type { DatabaseConnection, Driver, QueryResult } from "kysely";
 
 export interface DuckDbWasmDriverConfig {
-  database: (() => Promise<duckdb.AsyncDuckDB>) | duckdb.AsyncDuckDB;
-  onCreateConnection?: (conection: duckdb.AsyncDuckDBConnection) => Promise<void>;
+  /**
+   * AsyncDuckDB instance or a function that returns a Promise of an AsyncDuckDB instance.
+   * The database must already be instantiated before the dialect is initialized.
+   */
+  database: (() => Promise<AsyncDuckDB>) | AsyncDuckDB;
+  /**
+   * Called when a connection is created.
+   * @param conection AsyncDuckDBConnection instance that is created.
+   * @returns Promise<void>
+   */
+  onCreateConnection?: (conection: AsyncDuckDBConnection) => Promise<void>;
 }
 
 export class DuckDbWasmDriver implements Driver {
   readonly #config: DuckDbWasmDriverConfig;
-  #db?: duckdb.AsyncDuckDB;
+  #db?: AsyncDuckDB;
 
   constructor(config: DuckDbWasmDriverConfig) {
     this.#config = Object.freeze({ ...config });
@@ -28,7 +35,7 @@ export class DuckDbWasmDriver implements Driver {
     if (this.#config.onCreateConnection) {
       await this.#config.onCreateConnection(conn);
     }
-    return new DuckDBConnection(conn);
+    return new DuckDBWasmConnection(conn);
   }
 
   async beginTransaction(connection: DatabaseConnection): Promise<void> {
@@ -44,18 +51,18 @@ export class DuckDbWasmDriver implements Driver {
   }
 
   async releaseConnection(connection: DatabaseConnection): Promise<void> {
-    await (connection as DuckDBConnection).disconnect();
+    await (connection as DuckDBWasmConnection).disconnect();
   }
 
   async destroy(): Promise<void> {
-    await this.#db!.terminate();
+    await this.#db?.terminate();
   }
 }
 
-class DuckDBConnection implements DatabaseConnection {
-  readonly #conn: duckdb.AsyncDuckDBConnection;
+class DuckDBWasmConnection implements DatabaseConnection {
+  readonly #conn: AsyncDuckDBConnection;
 
-  constructor(conn: duckdb.AsyncDuckDBConnection) {
+  constructor(conn: AsyncDuckDBConnection) {
     this.#conn = conn;
   }
 
@@ -63,48 +70,90 @@ class DuckDBConnection implements DatabaseConnection {
     const { sql, parameters } = compiledQuery;
     const stmt = await this.#conn.prepare(sql);
 
-    const result = await stmt.query(...parameters);
-    return this.formatToResult(result, sql);
+    try {
+      const result = await stmt.query(...parameters);
+      return this.#formatToResult(result, this.#isMutationQuery(compiledQuery));
+    } finally {
+      await stmt.close();
+    }
   }
 
   async *streamQuery<R>(compiledQuery: CompiledQuery): AsyncIterableIterator<QueryResult<R>> {
     const { sql, parameters } = compiledQuery;
     const stmt = await this.#conn.prepare(sql);
 
-    const iter = await stmt.send(...parameters);
-    const self = this;
+    try {
+      const reader = await stmt.send(...parameters);
+      const isMutationQuery = this.#isMutationQuery(compiledQuery);
 
-    const gen = async function*() {
-      for await (const result of iter) {
-        yield self.formatToResult(result, sql);
+      for await (const result of reader) {
+        yield this.#formatToResult(result, isMutationQuery);
       }
-    };
-    return gen();
-  }
-
-  private formatToResult<O>(result: arrow.Table | arrow.RecordBatch, sql: string): QueryResult<O> {
-    const isSelect = result.schema.fields.length == 1
-      && result.schema.fields[0].name == "Count"
-      && result.numRows == 1
-      && sql.toLowerCase().includes("select");
-
-    if (isSelect) {
-      return { rows: result.toArray() as O[] };
-    } else {
-      const row = result.get(0);
-      const numAffectedRows = row == null ? undefined : BigInt(row["Count"]);
-
-      return {
-        numUpdatedOrDeletedRows: numAffectedRows,
-        numAffectedRows,
-        insertId: undefined,
-        rows: [],
-      };
+    } finally {
+      await stmt.close();
     }
   }
 
+  #isMutationQuery(compiledQuery: CompiledQuery): boolean {
+    switch (compiledQuery.query.kind) {
+      case "InsertQueryNode":
+      case "UpdateQueryNode":
+      case "DeleteQueryNode":
+      case "MergeQueryNode":
+        return true;
+      case "SelectQueryNode":
+        return false;
+      default:
+        return !compiledQuery.sql.trimStart().toLocaleLowerCase().startsWith("select");
+    }
+  }
+
+  #formatToResult<O>(result: ArrowResult, isMutationQuery: boolean): QueryResult<O> {
+    if (!isMutationQuery) {
+      return { rows: result.toArray().map((row) => this.#convertValue(row)) as O[] };
+    }
+
+    const row = result.get(0) as Record<string, unknown> | null | undefined;
+    const count = row == null ? undefined : row["Count"] ?? row["count"];
+    const numAffectedRows = count == null ? undefined : BigInt(count as string | number | bigint | boolean);
+
+    return {
+      numChangedRows: numAffectedRows,
+      numAffectedRows,
+      insertId: undefined,
+      rows: [],
+    };
+  }
+
   async disconnect(): Promise<void> {
-    return this.#conn.close();
+    await this.#conn.close();
+  }
+
+  #convertValue(value: unknown): unknown {
+    if (value == null) return value;
+    if (value instanceof Date) return value;
+    if (value instanceof Uint8Array) return Buffer.from(value);
+    if (Array.isArray(value)) return value.map((item) => this.#convertValue(item));
+    if (typeof value === "object") {
+      const entries = Object.entries(value);
+      if (entries.length === 0) return value;
+      const obj: Record<string, unknown> = {};
+      for (const [key, item] of entries) {
+        obj[key] = this.#convertValue(item);
+      }
+      return obj;
+    }
+    return value;
   }
 }
-*/
+
+interface ArrowResult {
+  readonly numRows: number;
+  readonly schema: {
+    readonly fields: ReadonlyArray<{
+      readonly name: string;
+    }>;
+  };
+  get(index: number): unknown;
+  toArray(): unknown[];
+}

--- a/src/driver-wasm.ts
+++ b/src/driver-wasm.ts
@@ -110,7 +110,7 @@ class DuckDBWasmConnection implements DatabaseConnection {
 
   #formatToResult<O>(result: ArrowResult, isMutationQuery: boolean): QueryResult<O> {
     if (!isMutationQuery) {
-      return { rows: result.toArray().map((row) => this.#convertValue(row)) as O[] };
+      return { rows: result.toArray().map((row) => this.#convertRow(row, result.schema.fields)) as O[] };
     }
 
     const row = result.get(0) as Record<string, unknown> | null | undefined;
@@ -129,10 +129,25 @@ class DuckDBWasmConnection implements DatabaseConnection {
     await this.#conn.close();
   }
 
-  #convertValue(value: unknown): unknown {
+  #convertRow(value: unknown, fields: ReadonlyArray<ArrowField>): unknown {
+    if (value == null || typeof value !== "object") return this.#convertValue(value);
+
+    const fieldByName = new Map(fields.map((field) => [field.name, field]));
+    const obj: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      obj[key] = this.#convertValue(item, fieldByName.get(key));
+    }
+    return obj;
+  }
+
+  #convertValue(value: unknown, field?: ArrowField): unknown {
     if (value == null) return value;
     if (value instanceof Date) return value;
     if (value instanceof Uint8Array) return Buffer.from(value);
+    if (this.#isArrowVector(value)) {
+      return Array.from(value.toArray()).map((item) => this.#convertValue(item));
+    }
+    if (field && this.#isTemporalField(field)) return this.#convertTemporalValue(value, field.type);
     if (Array.isArray(value)) return value.map((item) => this.#convertValue(item));
     if (typeof value === "object") {
       const entries = Object.entries(value);
@@ -145,6 +160,43 @@ class DuckDBWasmConnection implements DatabaseConnection {
     }
     return value;
   }
+
+  #isArrowVector(value: unknown): value is { toArray(): unknown[] } {
+    return typeof value === "object"
+      && value !== null
+      && "toArray" in value
+      && typeof (value as { toArray?: unknown }).toArray === "function";
+  }
+
+  #isTemporalField(field: ArrowField): boolean {
+    return field.type.typeId === ArrowTypeId.Date || field.type.typeId === ArrowTypeId.Timestamp;
+  }
+
+  #convertTemporalValue(value: unknown, type: ArrowType): unknown {
+    if (typeof value !== "number" && typeof value !== "bigint") return value;
+
+    const milliseconds = typeof value === "bigint" ? Number(value) : value;
+    if (type.typeId === ArrowTypeId.Timestamp && type.timezone) {
+      return new Date(milliseconds);
+    }
+
+    const utc = new Date(milliseconds);
+    return new Date(
+      utc.getUTCFullYear(),
+      utc.getUTCMonth(),
+      utc.getUTCDate(),
+      type.typeId === ArrowTypeId.Timestamp ? utc.getUTCHours() : 0,
+      type.typeId === ArrowTypeId.Timestamp ? utc.getUTCMinutes() : 0,
+      type.typeId === ArrowTypeId.Timestamp ? utc.getUTCSeconds() : 0,
+      type.typeId === ArrowTypeId.Timestamp ? utc.getUTCMilliseconds() : 0,
+    );
+  }
+
+}
+
+const enum ArrowTypeId {
+  Date = 8,
+  Timestamp = 10,
 }
 
 interface ArrowResult {
@@ -152,8 +204,19 @@ interface ArrowResult {
   readonly schema: {
     readonly fields: ReadonlyArray<{
       readonly name: string;
+      readonly type: ArrowType;
     }>;
   };
   get(index: number): unknown;
   toArray(): unknown[];
+}
+
+interface ArrowField {
+  readonly name: string;
+  readonly type: ArrowType;
+}
+
+interface ArrowType {
+  readonly typeId: number;
+  readonly timezone?: string | null;
 }

--- a/src/helper/datatypes.ts
+++ b/src/helper/datatypes.ts
@@ -50,12 +50,15 @@ export const blob = (buf: Buffer): RawBuilder<Buffer> => {
   }
   return sql`${byteStr.join("")}::BLOB`;
 };
-// DATE: extract calendar date as 'YYYY-MM-DD'. We use toISOString() here since
-// DuckDB interprets the literal string as a date without timezone. If you
-// construct Date via local components (e.g. new Date(y, m, d)), this remains
-// stable across time zones for negative offsets; for positive offsets, consider
-// formatting using local components instead.
-export const date = (date: Date): RawBuilder<Date> => sql`${date.toISOString().substring(0, 10)}::DATE`;
+// DATE is timezone-naive, so format from local calendar fields instead of UTC.
+export const date = (date: Date): RawBuilder<Date> => {
+  const formattedDate = [
+    String(date.getFullYear()).padStart(4, "0"),
+    pad(date.getMonth() + 1),
+    pad(date.getDate()),
+  ].join("-");
+  return sql`${formattedDate}::DATE`;
+};
 // const interval = ...
 export const list = <T>(values: T[]): RawBuilder<any[]> => sql`list_value(${sql.join(values)})`;
 export const map = <K, V>(values: [K, V][]): RawBuilder<any> => {
@@ -77,7 +80,6 @@ export const timestamp = <T extends Date | string>(value: T): RawBuilder<T> => {
     return sql`${value}::TIMESTAMP`;
   } else {
     // Format timestamp using local time components to match DuckDB TIMESTAMP semantics
-    const pad = (n: number, len = 2) => String(n).padStart(len, "0");
     const y = value.getFullYear();
     const mo = pad(value.getMonth() + 1);
     const d = pad(value.getDate());
@@ -99,3 +101,7 @@ export const timestamptz = <T extends Date | string>(value: T): RawBuilder<Date>
     return sql`${value.toISOString()}::TIMESTAMPTZ`;
   }
 };
+
+function pad(n: number, len = 2): string {
+  return String(n).padStart(len, "0");
+}

--- a/src/wasm-node.ts
+++ b/src/wasm-node.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
 import {
@@ -8,6 +9,8 @@ import {
   type Logger,
 } from "@duckdb/duckdb-wasm";
 
+const nodeRequire = createRequire(join(process.cwd(), "package.json"));
+
 export interface CreateDuckDbWasmDatabaseConfig {
   bundles?: DuckDBBundles;
   logger?: Logger;
@@ -16,7 +19,7 @@ export interface CreateDuckDbWasmDatabaseConfig {
 export async function createDuckDbWasmDatabase(
   config: CreateDuckDbWasmDatabaseConfig = {},
 ): Promise<AsyncDuckDB> {
-  const duckdbDist = dirname(require.resolve("@duckdb/duckdb-wasm/dist/duckdb-node.cjs"));
+  const duckdbDist = dirname(nodeRequire.resolve("@duckdb/duckdb-wasm/dist/duckdb-node.cjs"));
   const bundle = await selectBundle(config.bundles ?? createNodeBundles(duckdbDist));
   const worker = await createNodeWorker(bundle.mainWorker);
   const db = new AsyncDuckDB(config.logger ?? new VoidLogger(), worker);

--- a/src/wasm-node.ts
+++ b/src/wasm-node.ts
@@ -1,0 +1,46 @@
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  AsyncDuckDB,
+  selectBundle,
+  VoidLogger,
+  type DuckDBBundles,
+  type Logger,
+} from "@duckdb/duckdb-wasm";
+
+export interface CreateDuckDbWasmDatabaseConfig {
+  bundles?: DuckDBBundles;
+  logger?: Logger;
+}
+
+export async function createDuckDbWasmDatabase(
+  config: CreateDuckDbWasmDatabaseConfig = {},
+): Promise<AsyncDuckDB> {
+  const duckdbDist = dirname(require.resolve("@duckdb/duckdb-wasm/dist/duckdb-node.cjs"));
+  const bundle = await selectBundle(config.bundles ?? createNodeBundles(duckdbDist));
+  const worker = await createNodeWorker(bundle.mainWorker);
+  const db = new AsyncDuckDB(config.logger ?? new VoidLogger(), worker);
+  await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
+  return db;
+}
+
+function createNodeBundles(duckdbDist: string): DuckDBBundles {
+  return {
+    mvp: {
+      mainModule: join(duckdbDist, "duckdb-mvp.wasm"),
+      mainWorker: pathToFileURL(join(duckdbDist, "duckdb-node-mvp.worker.cjs")).href,
+    },
+    eh: {
+      mainModule: join(duckdbDist, "duckdb-eh.wasm"),
+      mainWorker: pathToFileURL(join(duckdbDist, "duckdb-node-eh.worker.cjs")).href,
+    },
+  };
+}
+
+async function createNodeWorker(workerUrl: string): Promise<Worker> {
+  const { default: WebWorker } = await import("web-worker");
+  return new WebWorker(workerUrl) as Worker;
+}
+
+export { DuckDbWasmDialect } from "./wasm";
+export type { DuckDbWasmDialectConfig } from "./wasm";

--- a/src/wasm.ts
+++ b/src/wasm.ts
@@ -1,0 +1,51 @@
+import {
+  type DatabaseIntrospector,
+  type Dialect,
+  type DialectAdapter,
+  type Driver,
+  Kysely,
+  type QueryCompiler,
+  type Simplify,
+} from "kysely";
+
+import { DuckDbAdapter } from "./adapter";
+import { DuckDbWasmDriver, type DuckDbWasmDriverConfig } from "./driver-wasm";
+import { DuckDbIntrospector } from "./introspector";
+import { DuckDbQueryCompiler, type DuckDbQueryCompilerConfigs } from "./query-compiler";
+
+export type DuckDbWasmDialectConfig = Simplify<DuckDbWasmDriverConfig & DuckDbQueryCompilerConfigs>;
+
+export class DuckDbWasmDialect implements Dialect {
+  constructor(private readonly config: DuckDbWasmDialectConfig) {
+  }
+
+  createQueryCompiler(): QueryCompiler {
+    return new DuckDbQueryCompiler(this.config);
+  }
+
+  createIntrospector(db: Kysely<any>): DatabaseIntrospector {
+    return new DuckDbIntrospector(db);
+  }
+
+  createDriver(): Driver {
+    return new DuckDbWasmDriver(this.config);
+  }
+
+  createAdapter(): DialectAdapter {
+    return new DuckDbAdapter();
+  }
+}
+
+export {
+  AsyncDuckDB,
+  ConsoleLogger,
+  getJsDelivrBundles,
+  selectBundle,
+  VoidLogger,
+} from "@duckdb/duckdb-wasm";
+export type {
+  AsyncDuckDBConnection,
+  DuckDBBundle,
+  DuckDBBundles,
+  Logger,
+} from "@duckdb/duckdb-wasm";

--- a/tests/insert_update.test.ts
+++ b/tests/insert_update.test.ts
@@ -62,3 +62,14 @@ test("update table", async () => {
   expect(res.length).toBe(1);
   expect(res[0].numUpdatedRows).toBe(BigInt(1));
 });
+
+test("delete reports affected row count", async () => {
+  const kysely = await setupDb();
+
+  const res = await kysely.deleteFrom("t1")
+    .where("a", "=", 1)
+    .execute();
+
+  expect(res.length).toBe(1);
+  expect(res[0].numDeletedRows).toBe(BigInt(1));
+});

--- a/tests/select.test.ts
+++ b/tests/select.test.ts
@@ -33,6 +33,7 @@ test("select complex data types", async () => {
   expect(row.bool).toEqual(true);
   expect(row.dt).toEqual(new Date(1992, 8, 20));
   expect(row.ts).toEqual(new Date(1992, 8, 20, 11, 30, 0, 123));
+  expect(row.tsz).toEqual(new Date("1992-09-20T08:30:00.123Z"));
   expect(row.enm).toEqual("sad");
   expect(row.delta).toEqual({ months: 12, days: 0, micros: 0 });
 });
@@ -73,4 +74,72 @@ test("tableMappings should respect .withSchema()", async () => {
   // With schema, should bypass tableMappings and read from the schema table
   const resultsFromSchema = await kysely.withSchema("other_schema").selectFrom("person").select(["first_name"]).execute();
   expect(resultsFromSchema).toEqual([{ first_name: "bar" }]);
+});
+
+test("timestamptz insert, select, and where preserve absolute instants", async () => {
+  const kysely = await setupDb();
+  const instant = new Date("1992-09-20T08:30:00.123Z");
+
+  await sql`CREATE TABLE tsz_cases (id INTEGER, tsz TIMESTAMPTZ);`.execute(kysely);
+  await sql`
+    INSERT INTO tsz_cases VALUES
+      (1, ${types.timestamptz("1992-09-20 11:30:00.123+03:00")}),
+      (2, ${types.timestamptz(instant)});
+  `.execute(kysely);
+
+  const selected = await sql<{ id: number; tsz: Date; }>`
+    SELECT id, tsz FROM tsz_cases ORDER BY id;
+  `.execute(kysely);
+  expect(selected.rows).toEqual([
+    { id: 1, tsz: instant },
+    { id: 2, tsz: instant },
+  ]);
+
+  const matchingOffset = await sql<{ id: number; }>`
+    SELECT id FROM tsz_cases
+    WHERE tsz = ${types.timestamptz("1992-09-20 05:30:00.123-03:00")}
+    ORDER BY id;
+  `.execute(kysely);
+  expect(matchingOffset.rows).toEqual([{ id: 1 }, { id: 2 }]);
+
+  const matchingDate = await sql<{ id: number; }>`
+    SELECT id FROM tsz_cases
+    WHERE tsz = ${types.timestamptz(instant)}
+    ORDER BY id;
+  `.execute(kysely);
+  expect(matchingDate.rows).toEqual([{ id: 1 }, { id: 2 }]);
+});
+
+test("round-trips date and timestamp helpers from Date values", async () => {
+  const kysely = await setupDb();
+  const dt = new Date(1992, 8, 20);
+  const ts = new Date(1992, 8, 20, 11, 30, 0, 123);
+  const tsz = new Date("1992-09-20T08:30:00.123Z");
+
+  await kysely.insertInto("t2")
+    .values({
+      int_list: types.list([9, 8, 7]),
+      string_list: types.list(["x", "y", "z"]),
+      m: types.map([["k", "v"]]),
+      st: types.struct({ x: sql.val(9), y: sql.val("z") }),
+      bs: types.bit("111000"),
+      bl: types.blob(Buffer.from([0xDD])),
+      bool: false,
+      dt: types.date(dt),
+      ts: types.timestamp(ts),
+      tsz: types.timestamptz(tsz),
+      enm: "ok",
+      delta: sql`INTERVAL 2 DAY`,
+    })
+    .execute();
+
+  const rows = await kysely.selectFrom("t2")
+    .select(["dt", "ts", "tsz"])
+    .where("bs", "=", types.bit("111000"))
+    .where("dt", "=", types.date(dt))
+    .where("ts", "=", types.timestamp(ts))
+    .where("tsz", "=", types.timestamptz(tsz))
+    .execute();
+
+  expect(rows).toEqual([{ dt, ts, tsz }]);
 });

--- a/tests/timezone.test.ts
+++ b/tests/timezone.test.ts
@@ -1,0 +1,46 @@
+import { sql } from "kysely";
+import * as types from "../src/helper/datatypes";
+import { setupDb } from "./test_common";
+
+const originalTz = process.env.TZ;
+
+afterAll(() => {
+  process.env.TZ = originalTz;
+});
+
+test.each(["UTC", "Asia/Tokyo", "America/New_York"])(
+  "date and timestamp helpers preserve local calendar fields in %s",
+  async (tz) => {
+    process.env.TZ = tz;
+    const kysely = await setupDb();
+    const dt = new Date(1992, 8, 20);
+    const ts = new Date(1992, 8, 20, 11, 30, 0, 123);
+
+    await kysely.insertInto("t2")
+      .values({
+        int_list: types.list([4, 5, 6]),
+        string_list: types.list(["tz", "case", tz]),
+        m: types.map([["tz", tz]]),
+        st: types.struct({ x: sql.val(4), y: sql.val(tz) }),
+        bs: types.bit("101010"),
+        bl: types.blob(Buffer.from([0xEF])),
+        bool: true,
+        dt: types.date(dt),
+        ts: types.timestamp(ts),
+        tsz: types.timestamptz("1992-09-20 11:30:00.123+03:00"),
+        enm: "happy",
+        delta: sql`INTERVAL 3 DAY`,
+      })
+      .execute();
+
+    const rows = await kysely.selectFrom("t2")
+      .select(["dt", "ts"])
+      .where("bs", "=", types.bit("101010"))
+      .where("dt", "=", types.date(dt))
+      .where("ts", "=", types.timestamp(ts))
+      .execute();
+
+    expect(rows).toEqual([{ dt, ts }]);
+    await kysely.destroy();
+  },
+);

--- a/tests/wasm.test.ts
+++ b/tests/wasm.test.ts
@@ -1,4 +1,4 @@
-import { CompiledQuery, Kysely } from "kysely";
+import { CompiledQuery, Kysely, sql } from "kysely";
 import { createDuckDbWasmDatabase, DuckDbWasmDialect } from "../src/wasm-node";
 
 interface WasmDatabase {
@@ -6,16 +6,37 @@ interface WasmDatabase {
     a: number;
     b: string;
   };
+  complex_values: {
+    id: number;
+    int_list: number[];
+    st: {
+      x: number;
+      y: string;
+    };
+    bl: Buffer;
+    dt: Date;
+    ts: Date;
+  };
+  seeded: {
+    id: number;
+  };
 }
 
-test("wasm dialect supports select, insert, affected rows, and cleanup", async () => {
+async function setupWasmDb(config: Partial<ConstructorParameters<typeof DuckDbWasmDialect>[0]> = {}) {
   const duckdb = await createDuckDbWasmDatabase();
   const kysely = new Kysely<WasmDatabase>({
     dialect: new DuckDbWasmDialect({
       database: duckdb,
       tableMappings: {},
+      ...config,
     }),
   });
+
+  return { duckdb, kysely };
+}
+
+test("wasm dialect supports select, insert, affected rows, and cleanup", async () => {
+  const { duckdb, kysely } = await setupWasmDb();
 
   try {
     const selectResult = await kysely
@@ -55,6 +76,116 @@ test("wasm dialect supports select, insert, affected rows, and cleanup", async (
       .select((eb) => eb.fn.count<number>("a").as("count"))
       .executeTakeFirstOrThrow();
     expect(count).toEqual({ count: BigInt(2) });
+  } finally {
+    await kysely.destroy();
+  }
+
+  expect(duckdb.isDetached()).toBe(true);
+});
+
+test("wasm dialect runs onCreateConnection and rolls back transactions", async () => {
+  let connectionsCreated = 0;
+  const { duckdb, kysely } = await setupWasmDb({
+    onCreateConnection: async (connection) => {
+      connectionsCreated += 1;
+      await connection.query("CREATE TABLE IF NOT EXISTS seeded (id INT);");
+    },
+  });
+
+  try {
+    await kysely.insertInto("seeded").values({ id: 1 }).execute();
+
+    await expect(kysely.transaction().execute(async (trx) => {
+      await trx.insertInto("seeded").values({ id: 2 }).execute();
+      throw new Error("rollback this transaction");
+    })).rejects.toThrow("rollback this transaction");
+
+    const rows = await kysely.selectFrom("seeded")
+      .selectAll()
+      .orderBy("id")
+      .execute();
+
+    expect(rows).toEqual([{ id: 1 }]);
+    expect(connectionsCreated).toBeGreaterThan(0);
+  } finally {
+    await kysely.destroy();
+  }
+
+  expect(duckdb.isDetached()).toBe(true);
+});
+
+test("wasm dialect streams rows", async () => {
+  const { duckdb, kysely } = await setupWasmDb();
+
+  try {
+    await kysely.executeQuery(CompiledQuery.raw("CREATE TABLE t1 (a INT, b VARCHAR);"));
+    await kysely.insertInto("t1")
+      .values([
+        { a: 1, b: "one" },
+        { a: 2, b: "two" },
+        { a: 3, b: "three" },
+      ])
+      .execute();
+
+    const rows = [];
+    for await (
+      const row of kysely.selectFrom("t1")
+        .selectAll()
+        .orderBy("a")
+        .stream()
+    ) {
+      rows.push(row);
+    }
+
+    expect(rows).toEqual([
+      { a: 1, b: "one" },
+      { a: 2, b: "two" },
+      { a: 3, b: "three" },
+    ]);
+  } finally {
+    await kysely.destroy();
+  }
+
+  expect(duckdb.isDetached()).toBe(true);
+});
+
+test("wasm dialect converts nested Arrow values and binary data", async () => {
+  const { duckdb, kysely } = await setupWasmDb();
+
+  try {
+    await sql`
+      CREATE TABLE complex_values (
+        id INT,
+        int_list INT[],
+        st STRUCT(x INT, y VARCHAR),
+        bl BLOB,
+        dt DATE,
+        ts TIMESTAMP
+      );
+    `.execute(kysely);
+    await sql`
+      INSERT INTO complex_values VALUES (
+        1,
+        [1, 2, 3],
+        {'x': 10, 'y': 'nested'},
+        '\\xAA\\xBB',
+        '1992-09-20',
+        '1992-09-20 11:30:00.123'
+      );
+    `.execute(kysely);
+
+    const row = await kysely.selectFrom("complex_values")
+      .selectAll()
+      .executeTakeFirstOrThrow();
+
+    expect(row).toEqual({
+      id: 1,
+      int_list: [1, 2, 3],
+      st: { x: 10, y: "nested" },
+      bl: Buffer.from([0xAA, 0xBB]),
+      dt: new Date(1992, 8, 20),
+      ts: new Date(1992, 8, 20, 11, 30, 0, 123),
+    });
   } finally {
     await kysely.destroy();
   }

--- a/tests/wasm.test.ts
+++ b/tests/wasm.test.ts
@@ -1,0 +1,63 @@
+import { CompiledQuery, Kysely } from "kysely";
+import { createDuckDbWasmDatabase, DuckDbWasmDialect } from "../src/wasm-node";
+
+interface WasmDatabase {
+  t1: {
+    a: number;
+    b: string;
+  };
+}
+
+test("wasm dialect supports select, insert, affected rows, and cleanup", async () => {
+  const duckdb = await createDuckDbWasmDatabase();
+  const kysely = new Kysely<WasmDatabase>({
+    dialect: new DuckDbWasmDialect({
+      database: duckdb,
+      tableMappings: {},
+    }),
+  });
+
+  try {
+    const selectResult = await kysely
+      .selectNoFrom((eb) => [
+        eb.val(1).as("a"),
+        eb.val("x").as("b"),
+      ])
+      .executeTakeFirstOrThrow();
+    expect(selectResult).toEqual({ a: 1, b: "x" });
+
+    await kysely.executeQuery(CompiledQuery.raw("CREATE TABLE t1 (a INT, b VARCHAR);"));
+    const insertResult = await kysely
+      .insertInto("t1")
+      .values([
+        { a: 1, b: "one" },
+        { a: 2, b: "two" },
+      ])
+      .executeTakeFirstOrThrow();
+
+    expect(insertResult.numInsertedOrUpdatedRows).toBe(BigInt(2));
+
+    const updateResult = await kysely
+      .updateTable("t1")
+      .set({ b: "updated" })
+      .where("a", "=", 2)
+      .executeTakeFirstOrThrow();
+    expect(updateResult.numUpdatedRows).toBe(BigInt(1));
+
+    const rows = await kysely.selectFrom("t1").selectAll().orderBy("a").execute();
+    expect(rows).toEqual([
+      { a: 1, b: "one" },
+      { a: 2, b: "updated" },
+    ]);
+
+    const count = await kysely
+      .selectFrom("t1")
+      .select((eb) => eb.fn.count<number>("a").as("count"))
+      .executeTakeFirstOrThrow();
+    expect(count).toEqual({ count: BigInt(2) });
+  } finally {
+    await kysely.destroy();
+  }
+
+  expect(duckdb.isDetached()).toBe(true);
+});

--- a/tests/wasm.test.ts
+++ b/tests/wasm.test.ts
@@ -16,6 +16,7 @@ interface WasmDatabase {
     bl: Buffer;
     dt: Date;
     ts: Date;
+    tsz: Date;
   };
   seeded: {
     id: number;
@@ -160,7 +161,8 @@ test("wasm dialect converts nested Arrow values and binary data", async () => {
         st STRUCT(x INT, y VARCHAR),
         bl BLOB,
         dt DATE,
-        ts TIMESTAMP
+        ts TIMESTAMP,
+        tsz TIMESTAMPTZ
       );
     `.execute(kysely);
     await sql`
@@ -170,7 +172,8 @@ test("wasm dialect converts nested Arrow values and binary data", async () => {
         {'x': 10, 'y': 'nested'},
         '\\xAA\\xBB',
         '1992-09-20',
-        '1992-09-20 11:30:00.123'
+        '1992-09-20 11:30:00.123',
+        '1992-09-20 11:30:00.123+03:00'
       );
     `.execute(kysely);
 
@@ -185,6 +188,7 @@ test("wasm dialect converts nested Arrow values and binary data", async () => {
       bl: Buffer.from([0xAA, 0xBB]),
       dt: new Date(1992, 8, 20),
       ts: new Date(1992, 8, 20, 11, 30, 0, 123),
+      tsz: new Date("1992-09-20T08:30:00.123Z"),
     });
   } finally {
     await kysely.destroy();


### PR DESCRIPTION
## Summary

- Add WASM entry points (`./wasm`, `./wasm-node`) and a `DuckDbWasmDialect` implementation.
- Add Node-compatible WASM setup helpers and package exports for CJS/ESM consumers.
- Update DuckDB runtime dependencies as part of WASM support: `@duckdb/node-api@1.5.2-r.1`, `@duckdb/duckdb-wasm@1.32.0`, and `web-worker@1.2.0`.
- Preserve PR #11 stream behavior by leaving the node driver stream fix as merged from upstream.
- Add timezone/date handling coverage plus WASM coverage for lifecycle cleanup, `onCreateConnection`, transaction rollback, streaming, Arrow list/struct conversion, BLOB conversion, DATE/TIMESTAMP conversion, and TIMESTAMPTZ conversion.
- Document WASM installation and usage.

## Review follow-up

- Fixed the `./wasm-node` ESM export so `import` resolves to `dist/wasm-node.mjs` while `require` continues to use `dist/wasm-node.js`.
- Reworked DuckDB WASM node file resolution through `createRequire` so the exported ESM entry point can resolve `@duckdb/duckdb-wasm` assets correctly.

## Validation

- `pnpm run check`
- `pnpm exec jest tests/wasm.test.ts --runInBand --testPathIgnorePatterns=.ralph`
- `pnpm exec jest --testPathIgnorePatterns=.ralph`
- `pnpm run build`
- `node -e "const mod = require('kysely-duckdb/wasm-node'); console.log(typeof mod.createDuckDbWasmDatabase, typeof mod.DuckDbWasmDialect);"`
- `node --input-type=module -e "const mod = await import('kysely-duckdb/wasm-node'); console.log(typeof mod.createDuckDbWasmDatabase, typeof mod.DuckDbWasmDialect);"`

## Notes

#12 has been merged, so this PR targets `main` directly.

`@duckdb/duckdb-wasm` is pinned to the latest non-dev stable version found on npm (`1.32.0`). `@duckdb/node-api` currently publishes `1.5.2-r.1` as the npm `latest` tag and does not have a plain semver stable release in the published versions list.